### PR TITLE
Fix `utf-8` argument

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -24,7 +24,7 @@ function get_input() {
 		error(`Could not find package.json`);
 	}
 
-	const pkg = JSON.parse(fs.readFileSync('package.json'), 'utf-8');
+	const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 
 	const unresolved = pkg.module || pkg.main || 'index';
 	const resolved = resolve(unresolved);


### PR DESCRIPTION
Instead of https://github.com/Rich-Harris/agadoo/pull/13.

`utf-8` should be an argument not of the `JSON.parse`, but rather `fs.readFileSync`.