### PR TITLE
fix license name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ If tree-shaking still fails, it's because Rollup thinks that there are side-effe
 
 ## License
 
-[LIL](LICENSE).
+[MIT](LICENSE).


### PR DESCRIPTION
The LICENSE and package.json files were updated, which are (probably?) the more legally binding ones, but the reference in the readme was not.